### PR TITLE
COMP: Fix compilation issues on Unix

### DIFF
--- a/Planner/Logic/vtkSlicerPlannerLogic.cxx
+++ b/Planner/Logic/vtkSlicerPlannerLogic.cxx
@@ -52,6 +52,7 @@
 
 // STD includes
 #include <cassert>
+#include <sstream>
 
 #define DEBUG(x) std::cout << "DEBUG: " << x << std::endl
 //#define DEBUG(x)
@@ -78,8 +79,8 @@ vtkSlicerPlannerLogic::vtkSlicerPlannerLogic()
   this->TargetPoints = NULL;
   this->Fiducials = NULL;
   this->cellLocator = NULL;
-  this->bendMode = BendModeType::Double;
-  this->bendSide = BendSide::A;
+  this->bendMode = Double;
+  this->bendSide = A;
   this->BendingPlane = NULL;
   this->BendingPlaneLocator = NULL;
   this->bendInitialized = false;
@@ -396,9 +397,22 @@ void vtkSlicerPlannerLogic::fillMetricsTable(vtkMRMLModelHierarchyNode* Hierarch
 
     int r1 = modelMetricsTable->AddEmptyRow();
     modelMetricsTable->SetCellText(0, 0, "ICV\n cm^3");
-    modelMetricsTable->SetCellText(0, 1, std::to_string(brainVolume).c_str());
-    modelMetricsTable->SetCellText(0, 2, std::to_string(preOpVolume).c_str());
-    modelMetricsTable->SetCellText(0, 3, std::to_string(currentVolume).c_str());
+    
+    std::stringstream brainVolumeSstr;
+    brainVolumeSstr << brainVolume;
+    const std::string& brainVolumeString = brainVolumeSstr.str();
+    modelMetricsTable->SetCellText(0, 1, brainVolumeString.c_str());
+    
+    std::stringstream preOpVolumeSstr;
+    preOpVolumeSstr << preOpVolume;
+    const std::string& preOpVolumeString = preOpVolumeSstr.str();
+    modelMetricsTable->SetCellText(0, 2, preOpVolumeString.c_str());
+    
+    std::stringstream currentVolumeSstr;
+    currentVolumeSstr << currentVolume;
+    const std::string& currentVolumeString = currentVolumeSstr.str();
+    modelMetricsTable->SetCellText(0, 3, currentVolumeString.c_str());
+    
   }
 }
 
@@ -440,20 +454,20 @@ vtkSmartPointer<vtkThinPlateSplineTransform> vtkSlicerPlannerLogic::getBendTrans
       this->SourcePointsDense->GetPoint(i, p);
       vtkVector3d point = (vtkVector3d)p;
       vtkVector3d bent = point;
-      if(this->bendMode == BendModeType::Double)
+      if(this->bendMode == Double)
       {
         bent = this->bendPoint2(point, magnitude);
       }
-      if(this->bendMode == BendModeType::Single)
+      if(this->bendMode == Single)
       {
-        if(this->bendSide == BendSide::A)
+        if(this->bendSide == A)
         {
           if(this->BendingPlane->EvaluateFunction(point.GetData())*this->BendingPlane->EvaluateFunction(this->SourcePoints->GetPoint(0)) > 0)
           {
             bent = this->bendPoint2(point, magnitude);
           }
         }
-        if(this->bendSide == BendSide::B)
+        if(this->bendSide == B)
         {
           if(this->BendingPlane->EvaluateFunction(point.GetData())*this->BendingPlane->EvaluateFunction(this->SourcePoints->GetPoint(1)) > 0)
           {

--- a/Planner/qSlicerPlannerModuleWidget.cxx
+++ b/Planner/qSlicerPlannerModuleWidget.cxx
@@ -75,6 +75,7 @@
 
 //STD includes
 #include <vector>
+#include <sstream>
 
 #define DEBUG(x) std::cout << "DEBUG: " << x << std::endl
 //#define DEBUG(x)
@@ -322,7 +323,11 @@ void qSlicerPlannerModuleWidgetPrivate::computeAndSetSourcePoints(vtkMRMLScene* 
   DEBUG("Try area");
 
   area->Update();
-  this->AreaBeforeBending->setText(std::to_string(area->GetSurfaceArea()).c_str());
+  
+  std::stringstream surfaceAreaSstr;
+  surfaceAreaSstr << area->GetSurfaceArea();
+  const std::string& surfaceAreaString= surfaceAreaSstr.str();
+  this->AreaBeforeBending->setText(surfaceAreaString.c_str());
 }
 
 
@@ -373,7 +378,12 @@ void qSlicerPlannerModuleWidgetPrivate::computeTransform(vtkMRMLScene* scene)
   DEBUG("Try area");
 
   area->Update();
-  this->AreaAfterBending->setText(std::to_string(area->GetSurfaceArea()).c_str());
+  
+  std::stringstream surfaceAreaSstr;
+  surfaceAreaSstr << area->GetSurfaceArea();
+  const std::string& surfaceAreaString= surfaceAreaSstr.str();
+  this->AreaAfterBending->setText(surfaceAreaString.c_str());
+  
   vtkSmartPointer<vtkPoints> targets = this->logic->getTargetPoints();
   this->ExtraFixedPoints->RemoveAllMarkups();
   for(int i = 0 ; i < targets->GetNumberOfPoints(); i++)
@@ -968,7 +978,7 @@ void qSlicerPlannerModuleWidgetPrivate::setScalarVisibility(bool visible)
     {
       childModel->GetDisplayNode()->SetActiveScalarName("Signed");
       childModel->GetDisplayNode()->SetScalarVisibility(visible);
-      childModel->GetDisplayNode()->SetScalarRangeFlag(vtkMRMLDisplayNode::ScalarRangeFlagType::UseDataScalarRange);
+      childModel->GetDisplayNode()->SetScalarRangeFlag(vtkMRMLDisplayNode::UseDataScalarRange);
     }
   }
 }


### PR DESCRIPTION
I fixed a few compilation issues that showed up in Unix.

1) Enum type value declaration

2) std::to_string method is  available in std=c++11 and later.  However, Slicer 4.8.1 builds only using C++98.  Hence, we can't use this method. I implemented a work around that uses stringstream