### PR TITLE
COMP: Fix CLI configuration warnings related to missing logo headers

### DIFF
--- a/OsteotomyModelToModelDistance/CMakeLists.txt
+++ b/OsteotomyModelToModelDistance/CMakeLists.txt
@@ -17,7 +17,6 @@ include(${SlicerExecutionModel_USE_FILE})
 #-----------------------------------------------------------------------------
 SEMMacroBuildCLI(
   NAME ${MODULE_NAME}
-  LOGO_HEADER ${Slicer_SOURCE_DIR}/Resources/NAMICLogo.h
   TARGET_LIBRARIES ${VTK_LIBRARIES}
   INCLUDE_DIRECTORIES
     ${vtkITK_INCLUDE_DIRS}

--- a/ShrinkWrap/CMakeLists.txt
+++ b/ShrinkWrap/CMakeLists.txt
@@ -19,7 +19,6 @@ include(${SlicerExecutionModel_USE_FILE})
 #-----------------------------------------------------------------------------
 SEMMacroBuildCLI(
   NAME ${MODULE_NAME}
-  LOGO_HEADER ${Slicer_SOURCE_DIR}/Resources/NAMICLogo.h
   TARGET_LIBRARIES ${VTK_LIBRARIES}
   INCLUDE_DIRECTORIES
     ${vtkITK_INCLUDE_DIRS}


### PR DESCRIPTION
This commit fixes warnings like the following:

```
  CMake Warning (dev) at /path/to/Slicer-Release/SlicerExecutionModel/CMake/SEMMacroBuildCLI.cmake:57 (message):
    Specified LOGO_HEADER [/Resources/NAMICLogo.h] doesn't exist
  Call Stack (most recent call first):
    ShrinkWrap/CMakeLists.txt:20 (SEMMacroBuildCLI)
  This warning is for project developers.  Use -Wno-dev to suppress it.
```