### PR TITLE
STYLE: Upgrade python syntax to 3.6 and newer

### DIFF
--- a/OsteotomyPlanner/OsteotomyPlanner.py
+++ b/OsteotomyPlanner/OsteotomyPlanner.py
@@ -687,21 +687,21 @@ class OsteotomyPlannerWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
       minMetricLabel = qt.QLabel('min')
       minMetricLabel.setAlignment(0x84)
       table.setCellWidget(0, 0, minMetricLabel)
-      minValueLabel = qt.QLabel("{:.6e}".format(distanceData.min()))
+      minValueLabel = qt.QLabel(f"{distanceData.min():.6e}")
       minValueLabel.setAlignment(0x84)
       table.setCellWidget(0, 1, minValueLabel)
 
       maxMetricLabel = qt.QLabel('max')
       maxMetricLabel.setAlignment(0x84)
       table.setCellWidget(1, 0, maxMetricLabel)
-      maxValueLabel = qt.QLabel("{:.6e}".format(distanceData.max()))
+      maxValueLabel = qt.QLabel(f"{distanceData.max():.6e}")
       maxValueLabel.setAlignment(0x84)
       table.setCellWidget(1, 1, maxValueLabel)
 
       meanMetricLabel = qt.QLabel('mean')
       meanMetricLabel.setAlignment(0x84)
       table.setCellWidget(2, 0, meanMetricLabel)
-      meanValueLabel = qt.QLabel("{:.6e}".format(distanceData.mean()))
+      meanValueLabel = qt.QLabel(f"{distanceData.mean():.6e}")
       meanValueLabel.setAlignment(0x84)
       table.setCellWidget(2, 1, meanValueLabel)
 
@@ -716,7 +716,7 @@ class OsteotomyPlannerWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
     self.ui.SubjectHierarchyTreeView.currentItems(itemList)
     self.activeNodes = []
     shNode = slicer.vtkMRMLSubjectHierarchyNode.GetSubjectHierarchyNode(slicer.mrmlScene)
-    if itemList.GetNumberOfIds() is not 0:
+    if itemList.GetNumberOfIds() != 0:
       for i in range(itemList.GetNumberOfIds()):
         node = shNode.GetItemDataNode(itemList.GetId(i))
         if (node is None) or (node.IsA('vtkMRMLModelNode') is False):
@@ -1020,7 +1020,7 @@ class OsteotomyPlannerLogic(ScriptedLoadableModuleLogic):
     slicer.mrmlScene.RemoveNode(cliNode)
 
     stopTime = time.time()
-    logging.info('Processing completed in {0:.2f} seconds'.format(stopTime-startTime))
+    logging.info(f'Processing completed in {stopTime-startTime:.2f} seconds')
 
 #
 # OsteotomyPlannerTest


### PR DESCRIPTION
Some syntax upgrading is necessary for Osteotomy Planner as I noticed in https://slicer.cdash.org/viewBuildError.php?buildid=2581624 that there were syntax warnings. These warnings are present because Slicer recently upgrade from Python 3.6.7 to Python 3.9.10 in https://github.com/Slicer/Slicer/commit/34e48e8aef5dad19ec8a955d6f48a1940846e3f3.

The syntax warning in question started as of Python 3.8.
https://docs.python.org/3.8/whatsnew/3.8.html#changes-in-python-behavior

> The compiler now produces a [SyntaxWarning](https://docs.python.org/3.8/library/exceptions.html#SyntaxWarning) when identity checks (is and is not) are used with certain types of literals (e.g. strings, numbers). These can often work by accident in CPython, but are not guaranteed by the language spec. The warning advises users to use equality tests (== and !=) instead. (Contributed by Serhiy Storchaka in [bpo-34850](https://bugs.python.org/issue34850).)

This PR uses [`pyupgrade`](https://github.com/asottile/pyupgrade) to automatically upgrade python syntax to newer versions. The script listed below was run for Python 3.6+ syntax with changes committed, followed by Python 3.7+, then Python 3.8+ and finally Python 3.9+.  There were no changes made when specifying Python 3.7+, 3.8+ or 3.9+ which is why there are no commits for those iterations.

## Using pyupgrade

- Install: `PythonSlicer -m pip install pyupgrade`
- Running:
  - On 1 file: `PythonSlicer -m pyupgrade --py36-plus MyPythonFile.py`
  - On multiple files: Here is my pyupgrade-script.py written to automate running pyupgrade across all python files in the Slicer repo. It was run by `PythonSlicer pyupgrade-script.py`.
```python
# pyupgrade-script.py
import os
import subprocess

search_directory = "C:/Users/JamesButler/Documents/GitHub/OsteotomyPlanner"
for root, _, files in os.walk(search_directory):
    for file_item in files:
        file_path = os.path.join(root, file_item)
        if os.path.isfile(file_path) and file_path.endswith(".py"):
            subprocess.call(["PythonSlicer", "-m", "pyupgrade", "--py36-plus", file_path])
```